### PR TITLE
composer: require ^1.12.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
 	"license": "BSD-3-Clause",
 	"require": {
 		"php": ">=5.2.11",
-		"zf1s/zend-config": "^1.12",
-		"zf1s/zend-exception": "^1.12",
-		"zf1s/zend-loader": "^1.12",
-		"zf1s/zend-registry": "^1.12",
-		"zf1s/zend-uri": "^1.12",
-		"zf1s/zend-view": "^1.12",
-		"zf1s/zend-xml": "^1.12"
+		"zf1s/zend-config": "^1.12.20",
+		"zf1s/zend-exception": "^1.12.20",
+		"zf1s/zend-loader": "^1.12.20",
+		"zf1s/zend-registry": "^1.12.20",
+		"zf1s/zend-uri": "^1.12.20",
+		"zf1s/zend-view": "^1.12.20",
+		"zf1s/zend-xml": "^1.12.20"
 	},
 	"autoload": {
 		"psr-0": {
@@ -31,8 +31,8 @@
 		"zf1s/zend-layout": "Used in special situations or with special adapters"
 	},
 	"replace": {
-    	"zf1/zend-controller": "^1.12"
-    },
+		"zf1/zend-controller": "^1.12"
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "1.x-dev"


### PR DESCRIPTION
require version that uses "replace" of old "zf1" namespace.

should fix problem reported here:
- https://github.com/zf1s/zend-application/pull/2#issuecomment-489571403

this is at least first level. but as i see, all interdependencies should be updated.

cc @falkenhawk